### PR TITLE
fix(doc): corrected link to demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # y-monaco
-> [Monaco](https://microsoft.github.io/monaco-editor/index.html) Editor Binding for [Yjs](https://github.com/y-js/yjs) - [Demo](https://yjs-demos.now.sh/monaco/)
+> [Monaco](https://microsoft.github.io/monaco-editor/index.html) Editor Binding for [Yjs](https://github.com/y-js/yjs) - [Demo](https://demos.yjs.dev/monaco/monaco.html)
 
 This binding maps a Y.Text to the Monaco editor (the editor that power VS Code).
 


### PR DESCRIPTION
old link: https://yjs-demos.now.sh/
new link: https://demos.yjs.dev/monaco/monaco.html

I nearly filed a bug report with https://github.com/yjs/yjs-demos telling ya the website was down 😂 .