### PR TITLE
Use Y.UndoManager

### DIFF
--- a/src/y-monaco.js
+++ b/src/y-monaco.js
@@ -198,8 +198,6 @@ export class MonacoBinding {
       })
       this.awareness = awareness
     }
-
-    
     editors.forEach(editor => {
       this.yUndoManager.trackedOrigins.add(this) // track changes performed by this editor binding
 
@@ -215,7 +213,6 @@ export class MonacoBinding {
         this.yUndoManager.redo()
       });
     })
-    
   }
 
   destroy () {

--- a/src/y-monaco.js
+++ b/src/y-monaco.js
@@ -198,9 +198,8 @@ export class MonacoBinding {
       })
       this.awareness = awareness
     }
+    this.yUndoManager.trackedOrigins.add(this) // track changes performed by this editor binding
     editors.forEach(editor => {
-      this.yUndoManager.trackedOrigins.add(this) // track changes performed by this editor binding
-
       editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.KEY_Z, () => {
         this.yUndoManager.undo()
       });

--- a/src/y-monaco.js
+++ b/src/y-monaco.js
@@ -200,7 +200,6 @@ export class MonacoBinding {
       })
       this.awareness = awareness
     }
-    this.yUndoManager.trackedOrigins.add(this) // track changes performed by this editor binding
     editors.forEach(editor => {
       editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.KEY_Z, () => {
         this.yUndoManager.undo()

--- a/src/y-monaco.js
+++ b/src/y-monaco.js
@@ -66,7 +66,9 @@ export class MonacoBinding {
     this.monacoModel = monacoModel
     this.editors = editors
     this.mux = createMutex()
-    this.yUndoManager = new Y.UndoManager(ytext)
+    this.yUndoManager = new Y.UndoManager(ytext, {
+      trackedOrigins: new Set([this])
+    })
     /**
      * @type {Map<monaco.editor.IStandaloneCodeEditor, RelativeSelection>}
      */


### PR DESCRIPTION
Resolves #9

I have reverted the change made in #8 and added `Y.UndoManager`.

It works for the most part, but there is an issue if someone makes a change at nearly the same time the other person triggers undo/redo operation. Here is a video to demonstrate:

https://user-images.githubusercontent.com/1868852/110636569-b373c980-81ac-11eb-9b51-70c51c28dce4.mov

On the left tab, I've created a function that inserts number "2" every 500ms, and on the right tab I'm triggering undo/redo command. You can see how undo affects the remote change.

I was trying to figure out why this happens, and it seems to me that in [`afterTransaction` handler](https://github.com/yjs/yjs/blob/main/src/utils/UndoManager.js#L205) `transaction.afterState` includes the change made by other person that is then pushed in undo stack. Shouldn't `beforeState` and `afterState` be isolated to a single transation?
 