### PR TITLE
don't call setValue unnecessarily

### DIFF
--- a/src/y-monaco.js
+++ b/src/y-monaco.js
@@ -156,7 +156,9 @@ export class MonacoBinding {
       this._rerenderDecorations()
     }
     ytext.observe(this._ytextObserver)
-    monacoModel.setValue(ytext.toString())
+    if (monacoModel.getValue() !== ytext.toString()) {
+      monacoModel.setValue(ytext.toString())
+    }
     this._monacoChangeHandler = monacoModel.onDidChangeContent(event => {
       // apply changes from right to left
       this.mux(() => {


### PR DESCRIPTION
Calling `monacoModel.setValue` unnecessarily when initiating monacobinding can cause unexpected side-effects, because it will trigger `onContentChanged` on the monaco model even though nothing changed.

I ran into this on several occasions, this should fix it safely

cc @dmonad 