### PR TITLE
add clientID to css classnames

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,19 @@ const binding = new MonacoBinding(type, editor.getModel(), new Set([editor]), pr
   <dd>Unregister all event listeners. This is automatically called when the model is disposed.</dd>
 </dl>
 
+## Styling
+
+You can use the following CSS classes to style remote cursor selections:
+
+- `yRemoteSelection`
+- `yRemoteSelectionHead`
+
+See [demo/index.html](demo/index.html) for example styles. Additionally, you can enable per-user styling (e.g.: different colors per user). The recommended approach for this is to listen to `awareness.on("update", () => ...));` and inject custom styles for every available clientId. You can use the following classnames for this:
+
+- `yRemoteSelection-${clientId}`
+- `yRemoteSelectionHead-${clientId`
+
+(where `${clientId}` is the Yjs clientId of the specific user).
 ### License
 
 [The MIT License](./LICENSE) © Kevin Jahns

--- a/src/y-monaco.js
+++ b/src/y-monaco.js
@@ -100,18 +100,18 @@ export class MonacoBinding {
                 if (anchorAbs.index < headAbs.index) {
                   start = monacoModel.getPositionAt(anchorAbs.index)
                   end = monacoModel.getPositionAt(headAbs.index)
-                  afterContentClassName = 'yRemoteSelectionHead'
+                  afterContentClassName = 'yRemoteSelectionHead yRemoteSelectionHead-' + clientID
                   beforeContentClassName = null
                 } else {
                   start = monacoModel.getPositionAt(headAbs.index)
                   end = monacoModel.getPositionAt(anchorAbs.index)
                   afterContentClassName = null
-                  beforeContentClassName = 'yRemoteSelectionHead'
+                  beforeContentClassName = 'yRemoteSelectionHead yRemoteSelectionHead-' + clientID
                 }
                 newDecorations.push({
                   range: new monaco.Range(start.lineNumber, start.column, end.lineNumber, end.column),
                   options: {
-                    className: 'yRemoteSelection',
+                    className: 'yRemoteSelection yRemoteSelection-' + clientID,
                     afterContentClassName,
                     beforeContentClassName
                   }


### PR DESCRIPTION
I would like to propose to add the clientID to the CSS classnames. This unlocks the use-case to give different clients different colors, and manage these via CSS.

In our project, we're storing a `color` property in yjs awareness. We then add a piece of CSS that sets thie style of `.yRemoteSelectionHead-${clientID}` to the corresponding color.