### PR TITLE
After manual destruction, don't destroy again on model disposal

### DIFF
--- a/src/y-monaco.js
+++ b/src/y-monaco.js
@@ -180,7 +180,7 @@ export class MonacoBinding {
         }, this)
       })
     })
-    monacoModel.onWillDispose(() => {
+    this._monacoDisposeHandler = monacoModel.onWillDispose(() => {
       this.destroy()
     })
     if (awareness) {
@@ -212,6 +212,7 @@ export class MonacoBinding {
 
   destroy () {
     this._monacoChangeHandler.dispose()
+    this._monacoDisposeHandler.dispose()
     this.ytext.unobserve(this._ytextObserver)
     this.doc.off('beforeAllTransactions', this._beforeTransaction)
     if (this.awareness) {


### PR DESCRIPTION
`destroy` doesn't remove the `onWillDispose` event handler from the model. This means that after a binding is manually destroyed, it will be destroyed again when the model is disposed.

This doesn't break anything but it does cause annoying `console.error`s from Yjs:

```
[yjs] Tried to remove event handler that doesn't exist. 
```