### PR TITLE
Support multi-selections in awareness

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,9 +57,15 @@ You can use the following CSS classes to style remote cursor selections:
 See [demo/index.html](demo/index.html) for example styles. Additionally, you can enable per-user styling (e.g.: different colors per user). The recommended approach for this is to listen to `awareness.on("update", () => ...));` and inject custom styles for every available clientId. You can use the following classnames for this:
 
 - `yRemoteSelection-${clientId}`
-- `yRemoteSelectionHead-${clientId`
+- `yRemoteSelectionHead-${clientId}`
 
 (where `${clientId}` is the Yjs clientId of the specific user).
+
+For multi-selection styling, use these classnames for the primary and secondary selections:
+
+- `yRemoteSelection-primary`, `yRemoteSelectionHead-primary`
+- `yRemoteSelection-secondary`, `yRemoteSelectionHead-secondary`
+
 ### License
 
 [The MIT License](./LICENSE) © Kevin Jahns

--- a/demo/index.html
+++ b/demo/index.html
@@ -12,6 +12,9 @@
         .yRemoteSelection {
             background-color: rgb(250, 129, 0, .5)
         }
+        .yRemoteSelection-secondary {
+            background-color: rgb(250, 129, 0, .3)
+        }
         .yRemoteSelectionHead {
             position: absolute;
             border-left: orange solid 2px;
@@ -20,6 +23,11 @@
             height: 100%;
             box-sizing: border-box;
         }
+        .yRemoteSelectionHead-secondary {
+            border-left: rgba(255, 166, 0, 0.7) solid 2px;
+            border-top: rgba(255, 166, 0, 0.7) solid 2px;
+            border-bottom: rgba(255, 166, 0, 0.7) solid 2px;
+        }
         .yRemoteSelectionHead::after {
             position: absolute;
             content: ' ';
@@ -27,6 +35,9 @@
             border-radius: 4px;
             left: -4px;
             top: -5px;
+        }
+        .yRemoteSelectionHead-secondary::after {
+            border: 3px solid rgba(255, 166, 0, 0.7);
         }
     </style>
 </head>


### PR DESCRIPTION
This PR is to support multi-selections in awareness, which is requested in #18.

- Refactored some code into util functions `createSelectionAnchorAndHead` and `createRemoteSelectionDecoration`.
- Added a new local state field `secondarySelections`, which is used to render decorations for secondary selections.
- Changed `createRelativeSelection` to `createRelativeSelections`, saving all current selections instead of only one.
- Added new classnames `yRemoteSelection-primary`, `yRemoteSelectionHead-primary`, `yRemoteSelection-secondary`, `yRemoteSelectionHead-secondary` for multi-selection styling, and added corresponding CSS in the demo file.

Demo:

https://github.com/yjs/y-monaco/assets/11325684/9d2d3cf4-0705-41af-897b-7a7cdceb54dc


cc @dmonad 

<!-- insert PR description above -->
-----
<a href="https://stackblitz.com/~/github/mosquitochang/y-monaco/tree/mosquitochang%2Fmulti-selections"><img src="https://developer.stackblitz.com/img/review_pr_small.svg" alt="Review PR in StackBlitz" align="left" width="103" height="20"></a> _Submitted with [StackBlitz](https://stackblitz.com/~/github/mosquitochang/y-monaco/tree/mosquitochang%2Fmulti-selections)._