### PR TITLE
Import the Monaco API without initializing the editor

### DIFF
--- a/src/y-monaco.js
+++ b/src/y-monaco.js
@@ -1,5 +1,5 @@
 import * as Y from 'yjs'
-import * as monaco from 'monaco-editor'
+import * as monaco from 'monaco-editor/esm/vs/editor/editor.api.js'
 import * as error from 'lib0/error'
 import { createMutex } from 'lib0/mutex'
 import { Awareness } from 'y-protocols/awareness' // eslint-disable-line


### PR DESCRIPTION
Currently, `y-monaco` is importing the entire `monaco-editor` package, rather than just the API that it uses. This means all languages are registered and all features are loaded, which is a pain if you're trying to only use a subset of Monaco functionality to keep bundle sizes down.

This PR changes the import to only pull in the bit of `monaco-editor` that `y-monaco` needs.